### PR TITLE
Fix typo in postgresql_setup

### DIFF
--- a/pkg/development.nix
+++ b/pkg/development.nix
@@ -49,7 +49,7 @@ rec {
     # set -m fixes ^C kill postgresql
     set -m
     # get options for -o from: `postgres --help`
-    pg_ctl -l $PGDATA/postgresql.log -o "-k $PGDATA" -h $PG_LISTENING_ADDRESS" start || exit
+    pg_ctl -l $PGDATA/postgresql.log -o "-k $PGDATA -h $PG_LISTENING_ADDRESS" start || exit
 
     createdb -h $PGDATA database_name
     psql -h $PGDATA database_name -c "COMMENT ON DATABASE sici_dev IS 'Database for Development, Testing & CI'" > /dev/null


### PR DESCRIPTION
Thanks for making this, it is a good source of inspiration for a similar setup I'm making. Your last commit introduced a typo which gives a very weird error message, so I thought I would upstream it just to spare others from debugging that :D

Also, elixir_1_10 doesn't exist in the pinned nixpkgs you use, so you should probably bump that or revert to elixir_1_9.