### PR TITLE
Remove deprecated use of `stdenv*.lib`

### DIFF
--- a/pkg/docs.nix
+++ b/pkg/docs.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, elixir, MIX_HOME, MIX_REBAR3, MIX_ENV, LANG, mix_deps, mix_build, hash ? null }:
+{ stdenvNoCC, lib, elixir, MIX_HOME, MIX_REBAR3, MIX_ENV, LANG, mix_deps, mix_build, hash ? null }:
 
 stdenvNoCC.mkDerivation rec {
   __noChroot = if hash == null then true else false;
@@ -34,5 +34,5 @@ stdenvNoCC.mkDerivation rec {
   outputHashMode = "recursive";
   outputHash = hash;
 
-  impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 }

--- a/pkg/mix_build.nix
+++ b/pkg/mix_build.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, elixir, MIX_HOME, MIX_REBAR3, MIX_ENV, LANG, mix_deps, hash ? null }:
+{ stdenvNoCC, lib, elixir, MIX_HOME, MIX_REBAR3, MIX_ENV, LANG, mix_deps, hash ? null }:
 
 stdenvNoCC.mkDerivation rec {
   __noChroot = if hash == null then true else false;
@@ -36,5 +36,5 @@ stdenvNoCC.mkDerivation rec {
   outputHashMode = "recursive";
   outputHash = hash;
 
-  impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 }

--- a/pkg/mix_deps.nix
+++ b/pkg/mix_deps.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, elixir, MIX_HOME, MIX_REBAR3, MIX_ENV, LANG, hash ? null }:
+{ stdenvNoCC, lib, elixir, MIX_HOME, MIX_REBAR3, MIX_ENV, LANG, hash ? null }:
 
 stdenvNoCC.mkDerivation rec {
   __noChroot = if hash == null then true else false;
@@ -25,5 +25,5 @@ stdenvNoCC.mkDerivation rec {
   outputHashMode = "recursive";
   outputHash = hash;
 
-  impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 }

--- a/pkg/node_modules.nix
+++ b/pkg/node_modules.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, nodejs, hash ? null }:
+{ stdenvNoCC, lib, nodejs, hash ? null }:
 
 stdenvNoCC.mkDerivation rec {
   __noChroot = if hash == null then true else false;
@@ -24,5 +24,5 @@ stdenvNoCC.mkDerivation rec {
   outputHashMode = "recursive";
   outputHash = hash;
 
-  impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 }

--- a/pkg/release.nix
+++ b/pkg/release.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, elixir, MIX_HOME, MIX_REBAR3, MIX_ENV, LANG, mix_deps, mix_build, release_name, nodejs, node_modules, hash ? null }:
+{ stdenvNoCC, lib, elixir, MIX_HOME, MIX_REBAR3, MIX_ENV, LANG, mix_deps, mix_build, release_name, nodejs, node_modules, hash ? null }:
 
 stdenvNoCC.mkDerivation rec {
   __noChroot = if hash == null then true else false;
@@ -46,5 +46,5 @@ stdenvNoCC.mkDerivation rec {
   outputHashMode = "recursive";
   outputHash = hash;
 
-  impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 }


### PR DESCRIPTION
 use top-level `lib` instead

